### PR TITLE
Check for null default on array

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1954,10 +1954,17 @@ def parse_default_value(type_name, value):
         construct_string = value[1:] if value[0:1] == "&" else value
         return f"StringName({construct_string})"
     elif type_name == "Array":
-        if value == "[  ]":
+        if value == "null":
+            return "Array()"
+        elif value == "[  ]":
+            return "Array()"
+        elif value == "[]":
+            return "Array()"
+        elif value == "Array()":
             return "Array()"
         else:
-            raise Exception(f"Array default value not implemented: type: {type_name}, value: {value}")
+            print(f"Array default value not implemented: type: {type_name}, value: {value}")
+            raise Exception("Array default value not implemented")
     elif type_name == "RID":
         return f"RID({value})"
     elif type_name == "Variant":


### PR DESCRIPTION
@vnen not sure if this is the right way to deal with this but it wouldn't allow me to set the default to null so just setting it to an empty array.. 

Fixes:
```
Exception: Array default value not implemented: type: Array, value: null:
  File "D:\Development\xr_plugins\godot_openvr.4.0\godot-cpp\SConstruct", line 415:
    binding_generator.generate_bindings(json_api_file, env['generate_template_get_node'])
File "D:\Development\xr_plugins\godot_openvr.4.0\godot-cpp\binding_generator.py", line 39:
    header = header_func(used_classes, c, use_template_get_node)
  File "D:\Development\xr_plugins\godot_openvr.4.0\godot-cpp\binding_generator.py", line 310:
    method_signature += " = " + parse_default_value(argument["type"], argument["default_value"])
  File "D:\Development\xr_plugins\godot_openvr.4.0\godot-cpp\binding_generator.py", line 1960:
    raise Exception(f"Array default value not implemented: type: {type_name}, value: {value}")
```