### PR TITLE
Remove unused import that breaks on windows

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import json
-from os import set_blocking
 import re
 import shutil
 from pathlib import Path


### PR DESCRIPTION
@vnen mostly submitting this for your attention, I'm not sure why this import was added but it gives an error on Windows that it doesn't exist.