### PR TITLE
Silence delete compile warning in memory.h/cpp on Windows

### DIFF
--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -44,6 +44,14 @@ _ALWAYS_INLINE_ void *operator new(size_t p_size, void *p_pointer, size_t check,
 	return p_pointer;
 }
 
+#ifdef _MSC_VER
+// When compiling with VC++ 2017, the above declarations of placement new generate many irrelevant warnings (C4291).
+// The purpose of the following definitions is to muffle these warnings, not to provide a usable implementation of placement delete.
+void operator delete(void *p_mem, const char *p_description);
+void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size));
+void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description);
+#endif
+
 namespace godot {
 
 class Memory {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -51,3 +51,22 @@ void Memory::free_static(void *p_ptr) {
 void *operator new(size_t p_size, const char *p_description) {
 	return godot::Memory::alloc_static(p_size);
 }
+
+using namespace godot;
+
+#ifdef _MSC_VER
+void operator delete(void *p_mem, const char *p_description) {
+	ERR_PRINT("Call to placement delete should not happen.");
+	CRASH_NOW();
+}
+
+void operator delete(void *p_mem, void *(*p_allocfunc)(size_t p_size)) {
+	ERR_PRINT("Call to placement delete should not happen.");
+	CRASH_NOW();
+}
+
+void operator delete(void *p_mem, void *p_pointer, size_t check, const char *p_description) {
+	ERR_PRINT("Call to placement delete should not happen.");
+	CRASH_NOW();
+}
+#endif


### PR DESCRIPTION
Fix memory warnings during compile on Windows MSVR