### PR TITLE
Fix variadic return

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1465,7 +1465,7 @@ def make_varargs_template(function_data, static=False):
 
     call_line = "\t\t"
 
-    if "return_value" in function_data and function_data["return_value"]["type"] != "void":
+    if return_type != "void":
         call_line += "return "
 
     call_line += f'{escape_identifier(function_data["name"])}_internal(call_args.data(), variant_args.size());'


### PR DESCRIPTION
I updated the check for return type. Fixes functions similar to the following:

![Clipboard - August 28, 2021 5 33 PM](https://user-images.githubusercontent.com/22453358/131221926-c18f8bf8-6c32-44a7-8f55-1a7f602bea3d.png)

(missing return before `str_internal`)