### PR TITLE
Minor CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 # Todo
 # Test build for Windows, Mac and mingw.
 
-project(godot-cpp)
+project(godot-cpp LANGUAGES CXX)
 cmake_minimum_required(VERSION 3.6)
 
 option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ else()
 	set(GENERATE_BINDING_PARAMETERS "False")
 endif()
 
-message(STATUS "Generating Bindings")
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import binding_generator; binding_generator.print_file_list(\"${GODOT_CUSTOM_API_FILE}\", \"${CMAKE_CURRENT_BINARY_DIR}\", headers=True, sources=True)"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	OUTPUT_VARIABLE GENERATED_FILES_LIST
@@ -142,7 +141,7 @@ add_custom_command(OUTPUT ${GENERATED_FILES_LIST}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		MAIN_DEPENDENCY ${GODOT_CUSTOM_API_FILE}
 		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/binding_generator.py
-		COMMENT Generating Bindings
+		COMMENT "Generating bindings"
 )
 
 # Get Sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(${PROJECT_NAME}
 		${HEADERS}
 		${GENERATED_FILES_LIST}
 )
+add_library(godot::cpp ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
 	PUBLIC
 	include


### PR DESCRIPTION
* Bindings are generated using `generate_bindings`, not at configure time, so I removed the confusing message.
* `COMMENT` value must be enclosed in quotation marks, otherwise only the first word will be displayed.
* Project languages ​​must be specified explicitly, otherwise CMake will also check the C compiler.
* Add namespaced alias (like `Boost::program_options` or `Qt5::Widgets`).