### PR TITLE
Convert float to double even if `meta` is set to float.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1561,6 +1561,8 @@ def correct_type(type_name, meta=None):
     if meta != None:
         if "int" in meta:
             return f"{meta}_t"
+        elif meta in type_conversion:
+            return type_conversion[type_name]
         else:
             return meta
     if type_name in type_conversion:


### PR DESCRIPTION
Godot will convert all floats it returns, and expects all floats we sent to it as parameters to be doubles. It will convert them between float and double as needed before interacting with the extension.

I guess this is to make the API more resilient once we start building godot with real_t_as_double even though it doesn't solve structs and classes using float where we want direct access to members and need correct typing.

Also I'm not sure what the benefit is of letting us know the original datatype is float if we're not exposing that so there is an argument that this is not the correct fix but that instead `meta` should always be set to double in the json. 