### PR TITLE
Add virtual destructor to Object class

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -961,6 +961,8 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
         result.append("")
         result.append("\ttemplate<class T>")
         result.append("\tstatic T *cast_to(Object *p_object);")
+
+        result.append("\tvirtual ~Object() {};")
     elif use_template_get_node and class_name == "Node":
         result.append("\ttemplate<class T>")
         result.append(


### PR DESCRIPTION
Our Object wrapper class needs to have a virtual destructor to make sure the correct destructor is called when destructing classes. As a bonus this also ensure that there is no shift in pointers when virtual methods are added later as our Object class now already has a v-table.