### PR TITLE
Fix PtrToArg encoding for `Object *`.

### DIFF
--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -169,7 +169,7 @@ struct PtrToArg<T *> {
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
-		p_ptr = p_var->_owner;
+		*((void **)p_ptr) = p_var->_owner;
 	}
 };
 
@@ -180,7 +180,7 @@ struct PtrToArg<const T *> {
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
-		p_ptr = p_var->_owner;
+		*((void **)p_ptr) = p_var->_owner;
 	}
 };
 


### PR DESCRIPTION
It didn't set the return value at all, changing the local value instead.
Now instead correctly sets it as a generic pointer type from `_owner`.