### PR TITLE
Proper initialization for godot-cpp classes with memnew.

### DIFF
--- a/godot-headers-temp/godot/gdnative_interface.h
+++ b/godot-headers-temp/godot/gdnative_interface.h
@@ -137,6 +137,7 @@ typedef void *GDNativeStringNamePtr;
 typedef void *GDNativeStringPtr;
 typedef void *GDNativeObjectPtr;
 typedef void *GDNativeTypePtr;
+typedef void *GDNativeExtensionPtr;
 typedef void *GDNativeMethodBindPtr;
 typedef int64_t GDNativeInt;
 typedef uint8_t GDNativeBool;
@@ -428,7 +429,8 @@ typedef struct {
 
 	/* CLASSDB */
 
-	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname);
+	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname, GDNativeExtensionPtr *r_extension);
+	GDNativeObjectPtr (*classdb_construct_object)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension);
 	GDNativeMethodBindPtr (*classdb_get_method_bind)(const char *p_classname, const char *p_methodname, GDNativeInt p_hash);
 	void *(*classdb_get_class_tag)(const char *p_classname);
 

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -162,9 +162,10 @@ public:                                                                         
 	};                                                                                                                                                            \
                                                                                                                                                                   \
 	static m_class *_new() {                                                                                                                                      \
-		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class);                                           \
+		static GDNativeExtensionPtr ___extension = nullptr;                                                                                                       \
+		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class, &___extension);                            \
 		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                         \
-		GDNativeObjectPtr obj = ___constructor();                                                                                                                 \
+		GDNativeObjectPtr obj = godot::internal::interface->classdb_construct_object(___constructor, ___extension);                                               \
 		return reinterpret_cast<m_class *>(godot::internal::interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \
 	}                                                                                                                                                             \
                                                                                                                                                                   \
@@ -205,7 +206,7 @@ public:                                                                         
 		___binding_reference_callback,                                                                                                                            \
 	};                                                                                                                                                            \
 	static m_class *_new() {                                                                                                                                      \
-		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class);                                           \
+		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class, nullptr);                                  \
 		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                         \
 		GDNativeObjectPtr obj = ___constructor();                                                                                                                 \
 		return reinterpret_cast<m_class *>(godot::internal::interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \


### PR DESCRIPTION
Calling the constructor alone is not enough if the class to be instantiated is not a base class.

See https://github.com/godotengine/godot/pull/52946