### PR TITLE
Fix creation (and godot-side deletion) of extended objects.

### DIFF
--- a/godot-headers-temp/godot/gdnative_interface.h
+++ b/godot-headers-temp/godot/gdnative_interface.h
@@ -137,6 +137,7 @@ typedef void *GDNativeStringNamePtr;
 typedef void *GDNativeStringPtr;
 typedef void *GDNativeObjectPtr;
 typedef void *GDNativeTypePtr;
+typedef void *GDNativeExtensionPtr;
 typedef void *GDNativeMethodBindPtr;
 typedef int64_t GDNativeInt;
 typedef uint8_t GDNativeBool;
@@ -428,7 +429,8 @@ typedef struct {
 
 	/* CLASSDB */
 
-	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname);
+	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname, GDNativeExtensionPtr *r_extension);
+	GDNativeObjectPtr (*classdb_construct_object)(GDNativeClassConstructor p_constructor, GDNativeExtensionPtr p_extension);
 	GDNativeMethodBindPtr (*classdb_get_method_bind)(const char *p_classname, const char *p_methodname, GDNativeInt p_hash);
 	void *(*classdb_get_class_tag)(const char *p_classname);
 

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -137,20 +137,22 @@ public:                                                                         
 	}                                                                                                                                                             \
                                                                                                                                                                   \
 	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                                                               \
-		Memory::free_static(reinterpret_cast<m_class *>(ptr));                                                                                                    \
+		if (ptr) {                                                                                                                                                \
+			m_class *cls = reinterpret_cast<m_class *>(ptr);                                                                                                      \
+			cls->~m_class();                                                                                                                                      \
+			::godot::Memory::free_static(cls);                                                                                                                    \
+		}                                                                                                                                                         \
 	}                                                                                                                                                             \
                                                                                                                                                                   \
 	static void set_object_instance(GDExtensionClassInstancePtr p_instance, GDNativeObjectPtr p_object_instance) {                                                \
-		reinterpret_cast<m_class *>(p_instance)->_owner = reinterpret_cast<GodotObject *>(p_object_instance);                                                     \
+		godot::internal::interface->object_set_instance_binding(p_object_instance, godot::internal::token, p_instance, &m_class::___binding_callbacks);           \
+		reinterpret_cast<m_class *>(p_instance)->_owner = reinterpret_cast<godot::GodotObject *>(p_object_instance);                                              \
 	}                                                                                                                                                             \
                                                                                                                                                                   \
 	static void *___binding_create_callback(void *p_token, void *p_instance) {                                                                                    \
-		m_class *result = new ("") m_class;                                                                                                                       \
-		result->_owner = reinterpret_cast<godot::GodotObject *>(p_instance);                                                                                      \
-		return result;                                                                                                                                            \
+		return nullptr;                                                                                                                                           \
 	}                                                                                                                                                             \
 	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                      \
-		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                                                              \
 	}                                                                                                                                                             \
 	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) {                                                \
 		return true;                                                                                                                                              \
@@ -162,9 +164,10 @@ public:                                                                         
 	};                                                                                                                                                            \
                                                                                                                                                                   \
 	static m_class *_new() {                                                                                                                                      \
-		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class);                                           \
+		static GDNativeExtensionPtr ___extension = nullptr;                                                                                                       \
+		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class, &___extension);                            \
 		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                         \
-		GDNativeObjectPtr obj = ___constructor();                                                                                                                 \
+		GDNativeObjectPtr obj = godot::internal::interface->classdb_construct_object(___constructor, ___extension);                                               \
 		return reinterpret_cast<m_class *>(godot::internal::interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \
 	}                                                                                                                                                             \
                                                                                                                                                                   \
@@ -205,7 +208,7 @@ public:                                                                         
 		___binding_reference_callback,                                                                                                                            \
 	};                                                                                                                                                            \
 	static m_class *_new() {                                                                                                                                      \
-		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class);                                           \
+		static GDNativeClassConstructor ___constructor = godot::internal::interface->classdb_get_constructor(#m_class, nullptr);                                  \
 		CHECK_CLASS_CONSTRUCTOR(___constructor, m_class);                                                                                                         \
 		GDNativeObjectPtr obj = ___constructor();                                                                                                                 \
 		return reinterpret_cast<m_class *>(godot::internal::interface->object_get_instance_binding(obj, godot::internal::token, &m_class::___binding_callbacks)); \

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -165,7 +165,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <class T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return reinterpret_cast<T *>(godot::internal::interface->object_get_instance_binding(p_ptr, godot::internal::token, T::___binding_callbacks));
+		return reinterpret_cast<T *>(godot::internal::interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
@@ -176,7 +176,7 @@ struct PtrToArg<T *> {
 template <class T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		return reinterpret_cast<const T *>(godot::internal::interface->object_get_instance_binding(p_ptr, godot::internal::token, T::___binding_callbacks));
+		return reinterpret_cast<const T *>(godot::internal::interface->object_get_instance_binding((void *)p_ptr, godot::internal::token, &T::___binding_callbacks));
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {

--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -10,6 +10,7 @@ func _ready():
 	($Example as Example).simple_const_func() # Force use of ptrcall
 	prints("returned", $Example.return_something("some string"))
 	prints("returned const", $Example.return_something_const())
+	prints("returned ref", $Example.return_extended_ref())
 	prints("vararg args", $Example.varargs_func("some", "arguments", "to", "test"))
 
 	# Use properties.

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -38,12 +38,21 @@
 
 using namespace godot;
 
+ExampleRef::ExampleRef() {
+	UtilityFunctions::print("ExampleRef created.");
+}
+
+ExampleRef::~ExampleRef() {
+	UtilityFunctions::print("ExampleRef destroyed.");
+}
+
 void Example::_bind_methods() {
 	// Methods.
 	ClassDB::bind_method(D_METHOD("simple_func"), &Example::simple_func);
 	ClassDB::bind_method(D_METHOD("simple_const_func"), &Example::simple_const_func);
 	ClassDB::bind_method(D_METHOD("return_something"), &Example::return_something);
 	ClassDB::bind_method(D_METHOD("return_something_const"), &Example::return_something_const);
+	ClassDB::bind_method(D_METHOD("return_extended_ref"), &Example::return_extended_ref);
 
 	{
 		MethodInfo mi;
@@ -92,6 +101,10 @@ Viewport *Example::return_something_const() const {
 		return result;
 	}
 	return nullptr;
+}
+
+ExampleRef *Example::return_extended_ref() const {
+	return memnew(ExampleRef());
 }
 
 Variant Example::varargs_func(const Variant **args, GDNativeInt arg_count, GDNativeCallError &error) {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -39,6 +39,17 @@
 
 using namespace godot;
 
+class ExampleRef : public RefCounted {
+	GDCLASS(ExampleRef, RefCounted);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	ExampleRef();
+	~ExampleRef();
+};
+
 class Example : public Control {
 	GDCLASS(Example, Control);
 
@@ -64,6 +75,7 @@ public:
 	void simple_const_func() const;
 	String return_something(const String &base);
 	Viewport *return_something_const() const;
+	ExampleRef *return_extended_ref() const;
 	Variant varargs_func(const Variant **args, GDNativeInt arg_count, GDNativeCallError &error);
 	void emit_custom_signal(const String &name, int value);
 

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -41,6 +41,7 @@
 using namespace godot;
 
 void register_example_types() {
+	ClassDB::register_class<ExampleRef>();
 	ClassDB::register_class<Example>();
 }
 


### PR DESCRIPTION
Proper initialization for godot-cpp classes with memnew.

Extension classes (i.e. the `GDCLASS` macro) behave differently from
regular wrapped classes, and requires Godot to initialize them during
object construction.

This commit update the GDCLASS macro to not create/destroy the instance
during the bindings callback, but during the extension callbacks.

When setting the object instance, the bindings instance is set to the
pointer of the extension instance so that it can later be retrieved
normally via `object_get_instance_bindings`.